### PR TITLE
AppCheckServer: add --ttl flag

### DIFF
--- a/AppCheckServer/package-lock.json
+++ b/AppCheckServer/package-lock.json
@@ -11,12 +11,14 @@
         "dedent": "^1.6.0",
         "firebase-admin": "^12.1.1",
         "http-status-codes": "^2.3.0",
+        "ms": "^2.1.3",
         "signale": "^1.4.0",
         "yargs": "^18.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.4.0",
         "@tsconfig/node20": "^20.1.4",
+        "@types/ms": "^2.1.0",
         "@types/node": "^20.14.2",
         "@types/signale": "^1.4.7",
         "@types/yargs": "^17.0.33",
@@ -723,6 +725,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1447,6 +1456,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2908,9 +2923,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {

--- a/AppCheckServer/package.json
+++ b/AppCheckServer/package.json
@@ -18,12 +18,14 @@
     "dedent": "^1.6.0",
     "firebase-admin": "^12.1.1",
     "http-status-codes": "^2.3.0",
+    "ms": "^2.1.3",
     "signale": "^1.4.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "@tsconfig/node20": "^20.1.4",
+    "@types/ms": "^2.1.0",
     "@types/node": "^20.14.2",
     "@types/signale": "^1.4.7",
     "@types/yargs": "^17.0.33",


### PR DESCRIPTION
This PR introduces a new command-line option, `--ttl`, to the AppCheckServer. This enhancement allows users to specify a custom Time-To-Live (TTL) value that the server will report in its App Check token responses. The primary purpose is to enable overriding the TTL presented to clients, which can be beneficial for testing client-side logic that depends on the token's reported expiration, without altering the actual validity period of the App Check token itself. This provides greater flexibility for development and testing scenarios.

### Highlights

* **New --ttl Command-Line Flag**: A new "--ttl" (or "-t") flag has been added to the AppCheckServer. This flag accepts a duration string (e.g., "5m", "1h") or a number in milliseconds, allowing for flexible input.
* **Configurable Reported TTL**: The server can now be configured to report a specific TTL value in the App Check token response, independent of the actual token's expiration. This is particularly useful for testing client-side logic that relies on the reported token lifetime.
* **Dependency Addition**: The "ms" package and its TypeScript types ("@types/ms") were added to the project dependencies. This addition facilitates the parsing of human-readable duration strings provided via the new "--ttl" flag.
